### PR TITLE
Feat: 할 일 생성 Modal API 연결 

### DIFF
--- a/components/Cards/CardList.tsx
+++ b/components/Cards/CardList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Card, CardListResponse } from "@/types/cards";
 import { getCards } from "@/utils/api/cardsApi";
 import Image from "next/image";
+import { getRandomColor, hexToRgba } from "@/utils/TodoForm";
 
 interface CardListProps {
   columnId: number;
@@ -26,7 +27,7 @@ const CardList: React.FC<CardListProps> = ({ columnId }) => {
   }, [columnId]);
 
   return (
-    <ul className="mt-[10px]">
+    <ul className="mt-4 flex flex-col gap-4">
       {cards.map((card) => (
         <li
           key={card.id}
@@ -46,14 +47,21 @@ const CardList: React.FC<CardListProps> = ({ columnId }) => {
             </h2>
             <div className="md:flex lg:block gap-4">
               <div className="tags flex items-center gap-[6px] mt-[6px]">
-                {card.tags.map((tag, index) => (
-                  <span
-                    key={index}
-                    className="tag py-1 px-[6px] rounded bg-[#F9EEE3] text-xs"
-                  >
-                    {tag}
-                  </span>
-                ))}
+                {card.tags.map((tag) => {
+                  const tagColor = getRandomColor();
+                  return (
+                    <span
+                      key={tag}
+                      className="tag py-1 px-[6px] rounded"
+                      style={{
+                        backgroundColor: hexToRgba(tagColor, 0.2),
+                        color: tagColor,
+                      }}
+                    >
+                      {tag}
+                    </span>
+                  );
+                })}
               </div>
               <div className="md:flex-1 flex justify-between items-center pt-[6px]">
                 <p className="flex items-center text-gray200 text-xs font-medium">

--- a/components/DashBoard/Column.tsx
+++ b/components/DashBoard/Column.tsx
@@ -2,18 +2,17 @@ import Image from "next/image";
 import CardList from "@/components/Cards/CardList";
 import useModal from "@/hooks/useModal";
 import CreateTodoModal from "@/components/UI/modal/CreateTodoModal";
-import { MemberProps } from "@/types/dashboards";
+import Portal from "../UI/modal/ModalPotal";
 
 interface ColumnProps {
   id: number;
   title: string;
-  members: MemberProps[];
 }
 
-const Column: React.FC<ColumnProps> = ({ id, title, members }) => {
+const Column: React.FC<ColumnProps> = ({ id, title }) => {
   const { isOpen, openModal, closeModal } = useModal();
 
-  const handleAddColumn = () => {
+  const handleAddCard = () => {
     openModal();
   };
   return (
@@ -33,7 +32,7 @@ const Column: React.FC<ColumnProps> = ({ id, title, members }) => {
       <button
         type="button"
         className="block w-full h-8 md:h-10 mt-6 border border-gray400 rounded-md bg-white100"
-        onClick={handleAddColumn}
+        onClick={handleAddCard}
       >
         <Image
           src="/images/icons/icon_add_column.svg"
@@ -45,12 +44,9 @@ const Column: React.FC<ColumnProps> = ({ id, title, members }) => {
       </button>
       <CardList columnId={id} />
       {isOpen && (
-        <CreateTodoModal
-          columnId={id}
-          members={members}
-          isOpen={isOpen}
-          onClose={closeModal}
-        />
+        <Portal>
+          <CreateTodoModal columnId={id} isOpen={isOpen} onClose={closeModal} />
+        </Portal>
       )}
     </div>
   );

--- a/components/DashBoard/ImageUpload.tsx
+++ b/components/DashBoard/ImageUpload.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import Image from "next/image";
+import { boxStyle, imageStyle, labelStyle } from "./styles";
+import { TodoFormProps } from "@/types/dashboards";
+import { createCardImage } from "@/utils/api/columnsApi";
+
+interface ImageUploadProps {
+  setFormData: React.Dispatch<React.SetStateAction<TodoFormProps>>;
+  preview: string | null;
+  columnId: number;
+}
+
+const ImageUpload = ({ setFormData, preview, columnId }: ImageUploadProps) => {
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (file) {
+      setFormData((prevData) => ({
+        ...prevData,
+        imageUrl: [file],
+      }));
+
+      try {
+        const response = await createCardImage({ columnId, image: file });
+        console.log("이미지 생성 성공:", response);
+      } catch (error) {
+        console.error("이미지 생성 실패:", error);
+      }
+    }
+  };
+
+  return (
+    <div className={`${boxStyle}`}>
+      <span className={`${labelStyle}`}>이미지</span>
+      <label
+        className="flex gap-2 md:w-[76px] sm:w-[58px]"
+        htmlFor="image"
+        aria-label="이미지 추가하기"
+      >
+        <Image
+          className={`cursor-pointer ${imageStyle}`}
+          src="/images/icons/icon_add_card.svg"
+          alt="이미지 추가"
+          width="76"
+          height="76"
+        />
+        {preview && (
+          <Image
+            src={preview}
+            alt="미리보기"
+            className={`rounded-[6px] object-cover ${imageStyle}`}
+            width="76"
+            height="76"
+          />
+        )}
+      </label>
+      <input
+        name="image"
+        id="image"
+        type="file"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+    </div>
+  );
+};
+
+export default ImageUpload;

--- a/components/DashBoard/TodoForm.tsx
+++ b/components/DashBoard/TodoForm.tsx
@@ -1,38 +1,31 @@
-import React, { useState, useEffect, useRef } from "react";
-import Image from "next/image";
-import {
-  boxStyle,
-  imageStyle,
-  inputStyle,
-  labelStyle,
-  textAreaStyle,
-} from "./styles";
+import React, { useState, useEffect } from "react";
 import { TodoFormProps, TodoModalProps } from "@/types/dashboards";
 import TodoButton from "./TodoButton";
-import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import { ko } from "date-fns/locale";
-import TodoTagList from "./TodoTagList";
-import { format } from "date-fns";
-import { getRandomColor, INITIAL_VALUES } from "@/utils/TodoForm";
+import { INITIAL_VALUES, validateForm } from "@/utils/TodoForm";
 import useImagePreview from "@/hooks/dashboard/useImagePreview";
 import { createCardImage } from "@/utils/api/columnsApi";
 import { createCard } from "@/utils/api/cardsApi";
 import { CreateCardBody } from "@/types/cards";
+import TitleInput from "./inputs/TitleInput";
+import DescriptionInput from "./inputs/DescriptionInput";
+import DateInput from "./inputs/DateInput";
+import TagInput from "./inputs/TagInput";
+import ImageUpload from "./ImageUpload";
+import UserInput from "./inputs/UserInput";
+import { format } from "date-fns";
 
-const ASSIGNEEUSER_ID = 4689;
 const DASHBOARD_ID = 12060;
 
 const TodoForm = ({
   columnId,
-  members,
   onClose,
+
   data = INITIAL_VALUES,
 }: TodoModalProps) => {
   const [formData, setFormData] = useState<TodoFormProps>(data);
-  const [tag, setTag] = useState<string>("");
+
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
-  const idRef = useRef<number>(0);
 
   const preview = useImagePreview(
     formData.imageUrl ? formData.imageUrl[0] : null
@@ -40,6 +33,7 @@ const TodoForm = ({
 
   useEffect(() => {
     const isFormComplete =
+      formData.assigneeUserId &&
       formData.title &&
       formData.description &&
       formData.dueDate &&
@@ -48,99 +42,25 @@ const TodoForm = ({
     setIsButtonDisabled(!isFormComplete);
   }, [formData]);
 
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-
-    if (file) {
-      setFormData((prevData) => ({
-        ...prevData,
-        imageUrl: [file],
-      }));
-
-      try {
-        const response = await createCardImage({ columnId, image: file });
-        console.log("이미지 생성 성공:", response);
-      } catch (error) {
-        console.error("이미지 생성 실패:", error);
-      }
-    }
-  };
-
-  const handleInputChange = (
-    e: React.ChangeEvent<
-      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-    >
-  ) => {
-    const { name, value } = e.target;
-    setFormData((prevData) => ({
-      ...prevData,
-      [name]: value,
-    }));
-  };
-
-  const handleDateChange = (date: Date | null) => {
-    setFormData((prevData) => ({
-      ...prevData,
-      dueDate: date || new Date(),
-    }));
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && tag.length > 0) {
-      e.preventDefault();
-      const newTag = {
-        text: tag,
-        color: getRandomColor(),
-        id: idRef.current++,
-      };
-      setFormData((prevData) => ({
-        ...prevData,
-        tags: [...prevData.tags, newTag],
-      }));
-      setTag("");
-    }
-  };
-
-  const handleDelete = (id: number) => {
-    const nextTags = formData.tags.filter((item) => item.id !== id);
-    setFormData((prevData) => ({
-      ...prevData,
-      tags: nextTags,
-    }));
-  };
-
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
-    let file: File | null = null;
-    if (formData.imageUrl && formData.imageUrl[0]) {
-      file = formData.imageUrl[0];
-    }
-
-    // 서버로 보내기 전에 formData 유효성 검사
-    if (
-      !formData.title ||
-      !formData.description ||
-      !formData.dueDate ||
-      !formData.tags.length ||
-      !file
-    ) {
-      console.error(
-        "유효성 검사 오류: 모든 필드가 올바르게 입력되었는지 확인하세요."
-      );
+    if (!validateForm(formData)) {
+      console.error("폼 유효성 검사 실패");
       return;
     }
 
     try {
-      const updatedImage = await createCardImage({
-        columnId,
-        image: file,
-      });
+      const file = formData.imageUrl ? formData.imageUrl[0] : null;
+      const updatedImage = await createCardImage({ columnId, image: file! });
+
+      if (!updatedImage || !updatedImage.imageUrl) {
+        throw new Error("이미지 업로드 실패");
+      }
 
       const outputData: CreateCardBody = {
-        assigneeUserId: ASSIGNEEUSER_ID,
+        assigneeUserId: formData.assigneeUserId,
         dashboardId: DASHBOARD_ID,
-        columnId: columnId,
+        columnId,
         title: formData.title,
         description: formData.description,
         dueDate: formData.dueDate
@@ -150,132 +70,47 @@ const TodoForm = ({
         imageUrl: updatedImage.imageUrl,
       };
 
-      await createCard(outputData);
-      setFormData(INITIAL_VALUES);
-      onClose();
+      try {
+        await createCard(outputData);
+
+        setFormData(INITIAL_VALUES);
+        onClose();
+      } catch (error) {
+        console.error(error);
+      }
     } catch (error) {
       console.error("제출 중 오류가 발생했습니다:", error);
     }
   };
+
   return (
     <form className="flex flex-col w-full text-[16px]" onSubmit={handleSubmit}>
-      <div className={`${boxStyle}`}>
-        <span className={`${labelStyle}`}>관리자</span>
-        <select
-          className={`${inputStyle}`}
-          name="manager"
-          value={ASSIGNEEUSER_ID}
-          onChange={handleInputChange}
-        >
-          <option value="temp1">문균</option>
-          {members &&
-            members.map((item) => (
-              <option key={item.id} value={item.nickname}>
-                {item.nickname}
-              </option>
-            ))}
-        </select>
-      </div>
+      <UserInput
+        value={formData.assigneeUserId}
+        onChange={(value) =>
+          setFormData({ ...formData, assigneeUserId: Number(value) })
+        }
+      />
 
-      <div className={`${boxStyle}`}>
-        <label className={`${labelStyle}`} htmlFor="title">
-          제목 <span className="text-purple100">*</span>
-        </label>
-        <input
-          className={`${inputStyle}`}
-          name="title"
-          id="title"
-          type="text"
-          placeholder="제목을 입력해 주세요."
-          value={formData.title}
-          onChange={handleInputChange}
-        />
-      </div>
+      <TitleInput
+        value={formData.title}
+        onChange={(value) => setFormData({ ...formData, title: value })}
+      />
+      <DescriptionInput
+        value={formData.description}
+        onChange={(value) => setFormData({ ...formData, description: value })}
+      />
+      <DateInput
+        value={formData.dueDate}
+        onChange={(date) => setFormData({ ...formData, dueDate: date! })}
+      />
+      <TagInput formData={formData} setFormData={setFormData} />
 
-      <div className={`${boxStyle}`}>
-        <label className={`${labelStyle}`} htmlFor="description">
-          설명 <span className="text-purple100">*</span>
-        </label>
-        <textarea
-          className={`${textAreaStyle}`}
-          name="description"
-          id="description"
-          placeholder="설명을 입력해 주세요."
-          value={formData.description}
-          onChange={handleInputChange}
-        />
-      </div>
-
-      <div className={`${boxStyle}`}>
-        <span className={`${labelStyle}`}>마감일</span>
-        <div className={`${inputStyle} flex items-center gap-2`}>
-          <Image
-            src="/images/icons/icon_calendar.svg"
-            alt="날짜"
-            width="22"
-            height="22"
-          />
-          <DatePicker
-            selected={formData.dueDate}
-            onChange={handleDateChange}
-            showTimeSelect
-            dateFormat="yyyy-MM-dd HH:mm"
-            placeholderText="날짜를 입력해 주세요"
-            locale={ko}
-            className="outline-none md:w-[460px] sm:w-[240px]"
-          />
-        </div>
-      </div>
-
-      <div className={`${boxStyle}`}>
-        <label className={`${labelStyle}`} htmlFor="tag">
-          태그
-        </label>
-        <input
-          className={`${inputStyle}`}
-          name="tag"
-          id="tag"
-          type="text"
-          placeholder="입력 후 Enter"
-          value={tag}
-          onChange={(e) => setTag(e.target.value)}
-          onKeyDown={handleKeyDown}
-        />
-        <TodoTagList formData={formData} onDelete={handleDelete} />
-      </div>
-
-      <div className={`${boxStyle}`}>
-        <span className={`${labelStyle}`}>이미지</span>
-        <label
-          className="flex gap-2 md:w-[76px] sm:w-[58px]"
-          htmlFor="image"
-          aria-label="이미지 추가하기"
-        >
-          <Image
-            className={`cursor-pointer ${imageStyle}`}
-            src="/images/icons/icon_add_card.svg"
-            alt="이미지 추가"
-            width="76"
-            height="76"
-          />
-          {preview && (
-            <Image
-              src={preview}
-              alt="미리보기"
-              className={`rounded-[6px] object-cover ${imageStyle}`}
-              width="76"
-              height="76"
-            />
-          )}
-        </label>
-        <input
-          name="image"
-          id="image"
-          type="file"
-          className="hidden"
-          onChange={handleFileChange}
-        />
-      </div>
+      <ImageUpload
+        setFormData={setFormData}
+        preview={preview}
+        columnId={columnId}
+      />
 
       <TodoButton onClose={onClose} text="생성" disabled={isButtonDisabled} />
     </form>

--- a/components/DashBoard/TodoTagList.tsx
+++ b/components/DashBoard/TodoTagList.tsx
@@ -1,14 +1,6 @@
 import { TodoFormProps } from "@/types/dashboards";
 import Image from "next/image";
 
-const hexToRgba = (hex: string, opacity: number) => {
-  const r = parseInt(hex.slice(1, 3), 16); // red
-  const g = parseInt(hex.slice(3, 5), 16); // green
-  const b = parseInt(hex.slice(5, 7), 16); // blue
-
-  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
-};
-
 const TodoTagList = ({
   formData,
   onDelete,
@@ -21,11 +13,7 @@ const TodoTagList = ({
       {formData.tags.map((tag) => (
         <li
           key={tag.id}
-          className="flex gap-1 items-center px-[6px] py-[6px] rounded"
-          style={{
-            backgroundColor: hexToRgba(tag.color, 0.2),
-            color: tag.color,
-          }}
+          className="flex gap-1 items-center px-[6px] py-[6px] rounded bg-gray500"
         >
           {tag.text}
           <Image

--- a/components/DashBoard/inputs/DateInput.tsx
+++ b/components/DashBoard/inputs/DateInput.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import DatePicker from "react-datepicker";
+import Image from "next/image";
+import { ko } from "date-fns/locale";
+import { boxStyle, inputStyle } from "../styles";
+
+interface DateInputProps {
+  value: Date | null;
+  onChange: (date: Date | null) => void;
+}
+
+const DateInput = ({ value, onChange }: DateInputProps) => {
+  return (
+    <div className={`${boxStyle}`}>
+      <span className="labelStyle">마감일</span>
+      <div className={`${inputStyle} flex items-center gap-2`}>
+        <Image
+          src="/images/icons/icon_calendar.svg"
+          alt="날짜"
+          width="22"
+          height="22"
+        />
+        <DatePicker
+          selected={value}
+          onChange={onChange}
+          showTimeSelect
+          dateFormat="yyyy-MM-dd HH:mm"
+          placeholderText="날짜를 입력해 주세요"
+          locale={ko}
+          className="outline-none md:w-[460px] sm:w-[240px]"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DateInput;

--- a/components/DashBoard/inputs/DescriptionInput.tsx
+++ b/components/DashBoard/inputs/DescriptionInput.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { boxStyle, textAreaStyle, labelStyle } from "../styles";
+
+interface DescriptionInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const DescriptionInput = ({ value, onChange }: DescriptionInputProps) => {
+  return (
+    <div className={`${boxStyle}`}>
+      <label className={`${labelStyle}`} htmlFor="description">
+        설명 <span className="text-purple100">*</span>
+      </label>
+      <textarea
+        className={`${textAreaStyle}`}
+        name="description"
+        id="description"
+        placeholder="설명을 입력해 주세요."
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
+};
+
+export default DescriptionInput;

--- a/components/DashBoard/inputs/TagInput.tsx
+++ b/components/DashBoard/inputs/TagInput.tsx
@@ -1,0 +1,58 @@
+import React, { useRef, useState } from "react";
+import { boxStyle, inputStyle, labelStyle } from "../styles";
+import TodoTagList from "../TodoTagList";
+import { TodoFormProps } from "@/types/dashboards";
+
+interface TagInputProps {
+  formData: TodoFormProps;
+  setFormData: React.Dispatch<React.SetStateAction<TodoFormProps>>;
+}
+
+const TagInput = ({ formData, setFormData }: TagInputProps) => {
+  const [tag, setTag] = useState<string>("");
+  const idRef = useRef<number>(0);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && tag.length > 0) {
+      e.preventDefault();
+      const newTag = {
+        text: tag,
+        id: idRef.current++,
+      };
+      setFormData((prevData) => ({
+        ...prevData,
+        tags: [...prevData.tags, newTag],
+      }));
+      setTag("");
+    }
+  };
+
+  const handleDelete = (id: number) => {
+    const nextTags = formData.tags.filter((item) => item.id !== id);
+    setFormData((prevData) => ({
+      ...prevData,
+      tags: nextTags,
+    }));
+  };
+
+  return (
+    <div className={`${boxStyle}`}>
+      <label className={`${labelStyle}`} htmlFor="tag">
+        태그
+      </label>
+      <input
+        className={`${inputStyle}`}
+        name="tag"
+        id="tag"
+        type="text"
+        placeholder="입력 후 Enter"
+        value={tag}
+        onChange={(e) => setTag(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      <TodoTagList formData={formData} onDelete={handleDelete} />
+    </div>
+  );
+};
+
+export default TagInput;

--- a/components/DashBoard/inputs/TitleInput.tsx
+++ b/components/DashBoard/inputs/TitleInput.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { boxStyle, inputStyle, labelStyle } from "../styles";
+
+interface TitleInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const TitleInput = ({ value, onChange }: TitleInputProps) => {
+  return (
+    <div className={`${boxStyle}`}>
+      <label className={`${labelStyle}`} htmlFor="title">
+        제목 <span className="text-purple100">*</span>
+      </label>
+      <input
+        className={`${inputStyle}`}
+        name="title"
+        id="title"
+        type="text"
+        placeholder="제목을 입력해 주세요."
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
+};
+
+export default TitleInput;

--- a/components/DashBoard/inputs/UserInput.tsx
+++ b/components/DashBoard/inputs/UserInput.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { getMembers } from "@/utils/api/dashboardsApi";
+import { boxStyle, inputStyle, labelStyle } from "../styles";
+import { MemberProps } from "@/types/dashboards";
+
+interface UserInputProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+const DASHBOARD_ID = 12060;
+
+const UserInput = ({ value, onChange }: UserInputProps) => {
+  const [members, setMembers] = useState<MemberProps[]>([]);
+  const fetchMembers = async () => {
+    try {
+      const { members } = await getMembers(DASHBOARD_ID);
+      setMembers(members);
+    } catch (error) {
+      console.error("Failed to fetch members:", error);
+    }
+  };
+  useEffect(() => {
+    fetchMembers();
+  }, []);
+
+  return (
+    <div className={`${boxStyle}`}>
+      <span className={`${labelStyle}`}>관리자</span>
+      <select
+        className={`${inputStyle} text-gray300`}
+        name="assigneeUserId"
+        value={value}
+        onChange={(e) => {
+          onChange(Number(e.target.value));
+        }}
+      >
+        <option value="default">이름을 입력해주세요</option>
+        {members.map((item) => (
+          <option key={item.id} value={item.userId}>
+            {item.nickname}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default UserInput;

--- a/components/UI/modal/CreateTodoModal.tsx
+++ b/components/UI/modal/CreateTodoModal.tsx
@@ -2,12 +2,7 @@ import TodoForm from "@/components/DashBoard/TodoForm";
 import ModalLayout from "@/components/Layout/ModalLayout";
 import { TodoModalProps } from "@/types/dashboards";
 
-const CreateTodoModal = ({
-  columnId,
-  members,
-  isOpen,
-  onClose,
-}: TodoModalProps) => {
+const CreateTodoModal = ({ columnId, isOpen, onClose }: TodoModalProps) => {
   if (!isOpen) return null;
 
   return (
@@ -17,7 +12,7 @@ const CreateTodoModal = ({
           <h2 className="md:text-[24px] sm:text-[20px] font-[700] md:mb-8 sm:mb-6">
             할 일 생성
           </h2>
-          <TodoForm columnId={columnId} members={members} onClose={onClose} />
+          <TodoForm columnId={columnId} onClose={onClose} />
         </div>
       </div>
     </ModalLayout>

--- a/components/UI/modal/ModalPotal.tsx
+++ b/components/UI/modal/ModalPotal.tsx
@@ -1,7 +1,7 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
-const Portal = ({ children }: { children: ReactElement }) => {
+const Portal = ({ children }: { children: ReactNode }) => {
   const [mounted, setMounted] = useState<boolean>(false);
 
   useEffect(() => {

--- a/pages/dashboards/[dashboardsId].tsx
+++ b/pages/dashboards/[dashboardsId].tsx
@@ -5,8 +5,8 @@ import { ColoumnsParams, Columns, ColumnsResponse } from "@/types/columns";
 import Image from "next/image";
 import Column from "@/components/DashBoard/Column";
 import DashBoardLayout from "@/components/Layout/DashBoardLayout";
-import Portal from "@/components/UI/Modal/ModalPotal";
-import OneInputModal from "@/components/UI/Modal/InputModal/OneInputModal";
+import Portal from "@/components/UI/modal/ModalPotal";
+import OneInputModal from "@/components/UI/modal/InputModal/OneInputModal";
 import { useOneInputModal } from "@/hooks/modal/useOneInputModal";
 
 const DashboardDetail: React.FC = () => {

--- a/types/dashboards.ts
+++ b/types/dashboards.ts
@@ -29,18 +29,22 @@ export interface MemberProps {
   userId: number;
   email: string;
   nickname: string;
-  profileImageUrl: string;
-  createdAt: string;
-  updatedAt: string;
-  isOwner: boolean;
+  profileImageUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  isOwner?: boolean;
+}
+export interface MembersResponse {
+  members: MemberProps[];
+  totalCount: number;
 }
 
 export interface TodoFormProps {
+  assigneeUserId: number;
   title: string;
   description: string;
   dueDate: Date | null;
   tags: {
-    color: string;
     text: string;
     id: number;
   }[];
@@ -49,7 +53,6 @@ export interface TodoFormProps {
 
 export interface TodoModalProps {
   columnId: number;
-  members: MemberProps[];
   isOpen?: boolean;
   onClose: () => void;
   data?: TodoFormProps;

--- a/utils/TodoForm.tsx
+++ b/utils/TodoForm.tsx
@@ -1,3 +1,5 @@
+import { TodoFormProps } from "@/types/dashboards";
+
 // 랜덤 색상 생성 함수
 export const getRandomColor = () => {
   const letters = "0123456789ABCDEF";
@@ -9,6 +11,7 @@ export const getRandomColor = () => {
 };
 
 export const INITIAL_VALUES = {
+  assigneeUserId: 0,
   title: "",
   description: "",
   dueDate: null,
@@ -17,12 +20,20 @@ export const INITIAL_VALUES = {
   manager: "",
 };
 
-// 파일을 Base64로 변환하는 유틸리티 함수
-// export const toBase64 = (file: File): Promise<string> => {
-//   return new Promise((resolve, reject) => {
-//     const reader = new FileReader();
-//     reader.readAsDataURL(file);
-//     reader.onload = () => resolve(reader.result as string);
-//     reader.onerror = (error) => reject(error);
-//   });
-// };
+export const validateForm = (formData: TodoFormProps) => {
+  return (
+    formData.title &&
+    formData.description &&
+    formData.dueDate &&
+    formData.tags.length > 0 &&
+    formData.imageUrl !== null
+  );
+};
+
+export const hexToRgba = (hex: string, opacity: number) => {
+  const r = parseInt(hex.slice(1, 3), 16); // red
+  const g = parseInt(hex.slice(3, 5), 16); // green
+  const b = parseInt(hex.slice(5, 7), 16); // blue
+
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+};

--- a/utils/api/dashboardsApi.ts
+++ b/utils/api/dashboardsApi.ts
@@ -1,4 +1,8 @@
-import { DashboardResponse, DashboardDetailResponse } from "@/types/dashboards";
+import {
+  DashboardResponse,
+  DashboardDetailResponse,
+  MembersResponse,
+} from "@/types/dashboards";
 import axiosInstance from "./axiosInstanceApi";
 
 // 대시보드 목록 가져오기
@@ -29,6 +33,22 @@ export const getDashboardDetail = async (
     return response.data;
   } catch (error) {
     console.error("Failed to fetch dashboard detail:", error);
+    throw error;
+  }
+};
+
+export const getMembers = async (
+  dashboardId: number,
+  page: number = 1,
+  size: number = 10
+): Promise<MembersResponse> => {
+  try {
+    const response = await axiosInstance.get(
+      `/members?page=${page}&size=${size}&dashboardId=${dashboardId}`
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Failed to fetch Members:", error);
     throw error;
   }
 };


### PR DESCRIPTION
## 🧩 이슈 번호
- [Taskify #41]

## 🔎 작업 내용

할 일 생성하기 기능을 구현했습니다. 하지만, 카드가 추가되고 바로 리렌더링되는 부분은 구현하지 못했습니다. 추후에 구현하겠습니다.

### 📌 createCardImage

- **Endpoint**: (예: https://sp-taskify-api.vercel.app/9-1/columns/40797/card-image)
- **Method**: POST
- **Purpose**: 카드 이미지 업로드를 위해 이미지의 링크를 만들어줍니다.

### 📌 createCard

- **Endpoint**: (예: https://sp-taskify-api.vercel.app/9-1/cards)
- **Method**: POST
- **Purpose**: 할 일 카드를 생성합니다.

### 📌 getMembers

- **Endpoint**: (예: https://sp-taskify-api.vercel.app/9-1/memberspage=1&size=10&dashboardId=40797)
- **Method**: GET
- **Purpose**: 초대된 맴버의 정보를 불러옵니다.

### 📌TodoForm.jsx 리펙토링
- TodoForm의 컴포넌트를 분리하고 코드의 가독성을 향상시켰습니다.


