### PR TITLE
Feat: 로딩 스피너 구현 

### DIFF
--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -1,0 +1,12 @@
+import { FadeLoader } from "react-spinners";
+
+const LoadingSpinner = ({ text }: { text: string }) => {
+  return (
+    <div className="flex flex-col items-center justify-center h-full">
+      <p className="text-2xl mb-4">{text}</p>
+      <FadeLoader color="#5534DA" />
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/components/My/MyProfile.tsx
+++ b/components/My/MyProfile.tsx
@@ -6,18 +6,33 @@ import useModal from "@/hooks/modal/useModal";
 import ModalAlert from "../UI/modal/ModalAlert";
 import { useProfileStore } from "@/store/profileStore";
 
-const MyProfile: React.FC = () => {
-  const { email, nickname, profileImageUrl, loadProfile, updateProfile } =
-    useProfileStore();
+interface MyProfileProps {
+  profileData: {
+    email: string;
+    nickname: string;
+    profileImageUrl: string | null;
+  } | null;
+}
 
-  const [newNickname, setNewNickname] = useState(nickname);
+const MyProfile: React.FC<MyProfileProps> = ({ profileData }) => {
+  const [newNickname, setNewNickname] = useState<string>(
+    profileData?.nickname || ""
+  ); // 초기값 설정
   const [newProfileImage, setNewProfileImage] = useState<File | undefined>(
     undefined
   );
   const [imagePreview, setImagePreview] = useState<string | null>(
-    profileImageUrl
-  ); // 이미지 프리뷰 상태
+    profileData?.profileImageUrl || null
+  ); // 초기값 설정
   const { isOpen, openModal, closeModal } = useModal();
+  const { updateProfile } = useProfileStore();
+  // 프로필 데이터가 변경될 경우 상태 업데이트
+  useEffect(() => {
+    if (profileData) {
+      setNewNickname(profileData.nickname);
+      setImagePreview(profileData.profileImageUrl);
+    }
+  }, [profileData]);
 
   // 파일 선택 시 이미지 업로드 처리
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -32,18 +47,11 @@ const MyProfile: React.FC = () => {
     }
   };
 
-  // 저장 버튼 클릭 시 프로필 업데이트
+  // 저장 버튼 클릭 시 프로필 업데이트 (API 호출 필요)
   const handleSave = async () => {
     await updateProfile(newNickname, newProfileImage);
     openModal();
   };
-
-  // 컴포넌트 마운트 시 프로필 정보 로드
-  useEffect(() => {
-    loadProfile();
-    setNewNickname(nickname);
-    setImagePreview(profileImageUrl);
-  }, [nickname, profileImageUrl, loadProfile]);
 
   return (
     <div className="lg:w-[672px] md:w-[548px] sm:w-[284px] md:p-6 sm:p-4 md:mb-6 sm:mb-4 rounded-2xl bg-white100">
@@ -80,7 +88,7 @@ const MyProfile: React.FC = () => {
               label="이메일"
               name="email"
               type="email"
-              value={email}
+              value={profileData?.email || ""}
               readOnly
             />
             <InputField

--- a/components/MyDashBoard/InvitedList.tsx
+++ b/components/MyDashBoard/InvitedList.tsx
@@ -5,7 +5,7 @@ import axiosInstance from "@/utils/api/axiosInstanceApi";
 import UnInvited from "./UnInvited";
 import SearchBox from "../UI/search/SearchBox";
 import InvitationList from "./invitationsList/InvitationList";
-import Loading from "../UI/loading/Loading";
+import LoadingSpinner from "../UI/loading/LoadingSpinner";
 import NoResults from "../UI/search/NoResults";
 import useDebounce from "@/hooks/dashboard/useDebounce";
 
@@ -85,7 +85,7 @@ const InvitedList = () => {
         </>
       )}
       {isLoadingMore && displayCount < filteredInvitations.length && (
-        <Loading />
+        <LoadingSpinner />
       )}
     </div>
   );

--- a/components/UI/loading/Loading.tsx
+++ b/components/UI/loading/Loading.tsx
@@ -1,8 +1,0 @@
-const Loading = () => (
-  <div className="flex items-center justify-center space-x-2 p-4">
-    <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-purple100"></div>
-    <span className="text-gray-600">로딩 중...</span>
-  </div>
-);
-
-export default Loading;

--- a/components/UI/loading/LoadingSpinner.tsx
+++ b/components/UI/loading/LoadingSpinner.tsx
@@ -1,6 +1,6 @@
 import { FadeLoader } from "react-spinners";
 
-const LoadingSpinner = ({ text }: { text: string }) => {
+const LoadingSpinner = ({ text }: { text?: string }) => {
   return (
     <div className="flex flex-col items-center justify-center h-full">
       <p className="text-2xl mb-4">{text}</p>

--- a/components/UI/loading/LoadingSpinner.tsx
+++ b/components/UI/loading/LoadingSpinner.tsx
@@ -3,7 +3,7 @@ import { FadeLoader } from "react-spinners";
 const LoadingSpinner = ({ text }: { text?: string }) => {
   return (
     <div className="flex flex-col items-center justify-center h-full">
-      <p className="text-2xl mb-4">{text}</p>
+      <p className="md:text-2xl mb-4 sm:text-lg">{text}</p>
       <FadeLoader color="#5534DA" />
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^18",
         "react-datepicker": "^7.5.0",
         "react-dom": "^18",
+        "react-spinners": "^0.14.1",
         "uuid": "^10.0.0",
         "zustand": "^5.0.0"
       },
@@ -6684,6 +6685,16 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-spinners": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.14.1.tgz",
+      "integrity": "sha512-2Izq+qgQ08HTofCVEdcAQCXFEYfqTDdfeDQJeo/HHQiQJD4imOicNLhkfN2eh1NYEWVOX4D9ok2lhuDB0z3Aag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^18",
     "react-datepicker": "^7.5.0",
     "react-dom": "^18",
+    "react-spinners": "^0.14.1",
     "uuid": "^10.0.0",
     "zustand": "^5.0.0"
   },

--- a/pages/dashboards/[dashboardsId]/index.tsx
+++ b/pages/dashboards/[dashboardsId]/index.tsx
@@ -14,6 +14,7 @@ import Portal from "@/components/UI/modal/ModalPotal";
 import OneInputModal from "@/components/UI/modal/InputModal/OneInputModal";
 import useModal from "@/hooks/modal/useModal";
 import { useAuthStore } from "@/store/authStore";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
 // DashboardDetailProps 인터페이스 정의 - 초기 유저 정보를 받는 props
 interface DashboardDetailProps {
@@ -25,7 +26,7 @@ const DashboardDetail: React.FC<DashboardDetailProps> = ({ initialUser }) => {
   const router = useRouter(); // Next.js의 useRouter 훅 사용
   const { dashboardsId } = router.query; // 쿼리 파라미터에서 dashboard ID 추출
   const [columns, setColumns] = useState<Columns[]>([]); // 칼럼 데이터 상태
-  const [loading, setLoading] = useState<boolean>(true); // 로딩 상태
+  const [loading, setLoading] = useState<boolean>(false); // 로딩 상태
   const [error, setError] = useState<string | null>(null); // 에러 상태
 
   // 모달 관련 훅 사용 (모달 열기, 닫기, 입력값 제어, 확인 함수 설정)
@@ -39,7 +40,7 @@ const DashboardDetail: React.FC<DashboardDetailProps> = ({ initialUser }) => {
   } = useModal();
 
   // 인증 관련 상태와 메서드 불러오기
-  const { user, setUser, checkAuth } = useAuthStore();
+  const { setUser, checkAuth } = useAuthStore();
 
   // 컴포넌트가 마운트될 때 initialUser가 있으면 유저 정보 설정, 없으면 인증 체크
   useEffect(() => {
@@ -59,6 +60,7 @@ const DashboardDetail: React.FC<DashboardDetailProps> = ({ initialUser }) => {
     const params: ColoumnsParams = { dashboardId }; // API 호출에 필요한 파라미터 설정
 
     try {
+      setLoading(true);
       const columnsData: ColumnsResponse = await getColumns(params); // 칼럼 데이터 API 호출
       setColumns(columnsData.data); // 상태에 칼럼 데이터 설정
     } catch (err) {
@@ -97,55 +99,58 @@ const DashboardDetail: React.FC<DashboardDetailProps> = ({ initialUser }) => {
   }, [dashboardsId, fetchColumns]);
 
   // 로딩 상태나 에러가 있을 때 로딩 및 에러 메시지 렌더링
-  if (loading) return <div>Loading...</div>;
+
   if (error) return <div>{error}</div>;
 
   // 실제 렌더링 부분
   return (
     <DashBoardLayout>
-      <div>
-        {user && <p>환영합니다, {user.nickname}님!</p>}
-        <div className="columns flex flex-col lg:flex-row">
-          {/* 각 칼럼 데이터를 Column 컴포넌트로 렌더링 */}
-          {columns.map((item) => (
-            <Column
-              key={item.id}
-              id={item.id}
-              title={item.title}
-              dashboardId={Number(dashboardsId)}
-            />
-          ))}
-          <div className="columnList flex-1 h-screen py-4 px-3 md:p-5 border-r border-[gray600]">
-            <button
-              type="button"
-              className="flex justify-center items-center gap-3 w-full sm:h-[66px] h-[70px] lg:mt-12 border border-gray400 rounded-md bg-white100 text-black300 font-bold"
-              onClick={handleAddColumn}
-            >
-              새로운 컬럼 추가하기
-              <Image
-                src="/images/icons/icon_add_column.svg"
-                width={16}
-                height={16}
-                alt="할 일 추가"
+      {!loading ? (
+        <div>
+          <div className="columns flex flex-col lg:flex-row">
+            {/* 각 칼럼 데이터를 Column 컴포넌트로 렌더링 */}
+            {columns.map((item) => (
+              <Column
+                key={item.id}
+                id={item.id}
+                title={item.title}
+                dashboardId={Number(dashboardsId)}
               />
-            </button>
+            ))}
+            <div className="columnList flex-1 h-screen py-4 px-3 md:p-5 border-r border-[gray600]">
+              <button
+                type="button"
+                className="flex justify-center items-center gap-3 w-full sm:h-[66px] h-[70px] lg:mt-12 border border-gray400 rounded-md bg-white100 text-black300 font-bold"
+                onClick={handleAddColumn}
+              >
+                새로운 컬럼 추가하기
+                <Image
+                  src="/images/icons/icon_add_column.svg"
+                  width={16}
+                  height={16}
+                  alt="할 일 추가"
+                />
+              </button>
+            </div>
+            <Portal>
+              <OneInputModal
+                isOpen={isOpen}
+                modalTitle="새 칼럼 생성"
+                inputLabel="이름"
+                inputPlaceholder="컬럼 이름을 입력해주세요"
+                onCancel={closeModal}
+                cancelButtonText="취소"
+                onConfirm={() => handleModalConfirm(handleConfirm)}
+                confirmButtonText="생성"
+                inputValue={inputValue}
+                onInputChange={handleInputChange}
+              />
+            </Portal>
           </div>
-          <Portal>
-            <OneInputModal
-              isOpen={isOpen}
-              modalTitle="새 칼럼 생성"
-              inputLabel="이름"
-              inputPlaceholder="컬럼 이름을 입력해주세요"
-              onCancel={closeModal}
-              cancelButtonText="취소"
-              onConfirm={() => handleModalConfirm(handleConfirm)}
-              confirmButtonText="생성"
-              inputValue={inputValue}
-              onInputChange={handleInputChange}
-            />
-          </Portal>
         </div>
-      </div>
+      ) : (
+        <LoadingSpinner text={"로딩중입니다! 잠시만 기다려주세요🙂‍↕️"}/>
+      )}
     </DashBoardLayout>
   );
 };

--- a/pages/dashboards/[dashboardsId]/index.tsx
+++ b/pages/dashboards/[dashboardsId]/index.tsx
@@ -14,7 +14,7 @@ import Portal from "@/components/UI/modal/ModalPotal";
 import OneInputModal from "@/components/UI/modal/InputModal/OneInputModal";
 import useModal from "@/hooks/modal/useModal";
 import { useAuthStore } from "@/store/authStore";
-import LoadingSpinner from "@/components/LoadingSpinner";
+import LoadingSpinner from "@/components/UI/loading/LoadingSpinner";
 
 // DashboardDetailProps 인터페이스 정의 - 초기 유저 정보를 받는 props
 interface DashboardDetailProps {
@@ -149,7 +149,7 @@ const DashboardDetail: React.FC<DashboardDetailProps> = ({ initialUser }) => {
           </div>
         </div>
       ) : (
-        <LoadingSpinner text={"로딩중입니다! 잠시만 기다려주세요🙂‍↕️"}/>
+        <LoadingSpinner text={"로딩중입니다! 잠시만 기다려주세요🙂‍↕️"} />
       )}
     </DashBoardLayout>
   );

--- a/pages/my/index.tsx
+++ b/pages/my/index.tsx
@@ -2,12 +2,36 @@ import DashBoardLayout from "@/components/Layout/DashBoardLayout";
 import MyPassWord from "@/components/My/MyPassWord";
 import MyProfile from "@/components/My/MyProfile";
 import { useRouter } from "next/router";
+import { GetServerSideProps } from "next";
+import { getUserInfo } from "@/utils/api/authApi";
+import { ProfileProps } from "@/types/my";
+import { parseCookies } from "nookies";
 
-const MyPage = () => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const cookies = parseCookies(context); // 쿠키 파싱
+
+  try {
+    // 쿠키에서 필요한 인증 토큰을 가져오기
+    const accessToken = cookies.accessToken; // 쿠키 이름에 맞게 수정
+
+    const profileData = await getUserInfo(accessToken); // 서버에서 프로필 데이터 가져오기
+    return {
+      props: { profileData }, // 데이터를 props로 전달
+    };
+  } catch (error) {
+    console.error("프로필 정보를 불러오는 중 오류 발생했습니다.", error);
+    return {
+      props: { profileData: null }, // 오류 발생 시 null 전달
+    };
+  }
+};
+
+const MyPage = ({ profileData }: { profileData: ProfileProps }) => {
   const router = useRouter();
   const returnButton = () => {
     router.back();
   };
+
   return (
     <DashBoardLayout>
       <div className="mt-5 ml-5 md:mb-[136px] sm:mb-[61px] min-h-screen">
@@ -17,7 +41,7 @@ const MyPage = () => {
         >
           &lt; 돌아가기
         </button>
-        <MyProfile />
+        <MyProfile profileData={profileData} />
         <MyPassWord />
       </div>
     </DashBoardLayout>


### PR DESCRIPTION
## 🧩 이슈 번호 
- [Taskify #83 ]

  <br/>

## 🔎 작업 내용

- LoadingSpinner 컴포넌트를 만들었고 prop로는 text를 지정해줄 수 있습니다.

- dashboard 페이지에서 컬럼 및 카드 데이터를 불러올 때, 로딩 스피너를 보이게 했습니다. 

![image (3)](https://github.com/user-attachments/assets/91e4efaf-a71c-4a56-9411-1a4c2f3dcdf0)

- 또한, 초대 리스트에서도 임시로 만들어진 Loading 컴포넌트를 LoadingSpinner 컴포넌트로 대체했습니다. 

