### PR TITLE
Bug(105) : 모달 팝업 시 아바타 그룹이 하이라이트 되는 오류 

### DIFF
--- a/components/MyDashBoard/AvatarGroup.tsx
+++ b/components/MyDashBoard/AvatarGroup.tsx
@@ -32,7 +32,7 @@ const AvatarGroup = () => {
   }, [dashboardsId]);
 
   return (
-    <div className="flex items-center ml-4">
+    <div className="flex items-center ml-4 relative z-0">
       {avatars.slice(0, showCountThreshold).map((member, index) => (
         <div
           key={member.id}


### PR DESCRIPTION
## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->
- #105 

  <br/>

## 🔎 작업 내용

- 아바타 그룹을 감싸고 있는 부모 div의 z-index를 다른 UI 요소보다 낮게 가지도록 수정하였습니다. 

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/c42d8797-72fe-4050-b245-a721152c8e56)

<br/>

## 🔧 앞으로의 과제

- 제가 모든 모달을 확인해보지 못했지만, 아까 낮에 말씀하셨던 컬럼수정이나 할일 생성시 발생하는 오류는 해결되는것은 확인이 되었습니다.
- 혹시 안되면 말씀해주세여
  <br/>


## 변경 로직

### 변경 전
### 변경 후


## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
