### PR TITLE
Refactor: modalAlert type 추가 

### DIFF
--- a/components/DashBoard/column/ColumnHeader.tsx
+++ b/components/DashBoard/column/ColumnHeader.tsx
@@ -1,5 +1,7 @@
+import React, { useState } from "react";
 import OneInputModal from "@/components/UI/modal/InputModal/OneInputModal";
 import Portal from "@/components/UI/modal/ModalPotal";
+import ModalAlert from "@/components/UI/modal/ModalAlert";
 import useModal from "@/hooks/modal/useModal";
 import { ColumnsUpdateParams } from "@/types/columns";
 import { deleteColumn, updateColumn } from "@/utils/api/columnsApi";
@@ -14,16 +16,17 @@ const ColumnHeader = ({
   columnId: number;
   onRefresh: () => void;
 }) => {
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
   const {
     isOpen,
     inputValue,
     openModal: handleSettingColumn,
     closeModal,
     handleInputChange,
-    handleConfirm: handleModalConfirm,
   } = useModal();
 
-  const handleDeleteColumn = async (columnId: number) => {
+  const handleDeleteColumn = async () => {
     try {
       await deleteColumn(columnId);
       closeModal();
@@ -46,6 +49,11 @@ const ColumnHeader = ({
     }
   };
 
+  const handleConfirmUpdate = () => {
+    handleUpdateColumn({ columnId, title: inputValue });
+    setIsAlertOpen(false);
+  };
+
   return (
     <h2 className="flex items-center gap-2 text-black100 font-bold">
       <span className="block w-2 h-2 rounded-full bg-purple100"></span>
@@ -66,16 +74,34 @@ const ColumnHeader = ({
             inputLabel="이름"
             inputPlaceholder={title}
             onCancel={closeModal} // X 버튼용 기본 닫기
-            cancelAction={() => handleDeleteColumn(columnId)}
+            cancelAction={() => setIsDeleteAlertOpen(true)}
             cancelButtonText="삭제"
-            onConfirm={() =>
-              handleModalConfirm(() =>
-                handleUpdateColumn({ columnId, title: inputValue })
-              )
-            }
+            onConfirm={() => setIsAlertOpen(true)}
             confirmButtonText="변경"
             inputValue={inputValue}
             onInputChange={handleInputChange}
+          />
+        </Portal>
+      )}
+      {isAlertOpen && (
+        <Portal>
+          <ModalAlert
+            isOpen={isAlertOpen}
+            type="confirm"
+            text="컬럼을 수정하시겠습니까?"
+            onClose={() => setIsAlertOpen(false)}
+            onConfirm={handleConfirmUpdate}
+          />
+        </Portal>
+      )}
+      {isDeleteAlertOpen && (
+        <Portal>
+          <ModalAlert
+            isOpen={isDeleteAlertOpen}
+            type="confirm"
+            text="컬럼을 삭제하시겠습니까?"
+            onClose={() => setIsDeleteAlertOpen(false)}
+            onConfirm={handleDeleteColumn}
           />
         </Portal>
       )}

--- a/components/UI/modal/ModalAlert.tsx
+++ b/components/UI/modal/ModalAlert.tsx
@@ -6,9 +6,16 @@ interface ModalAlertProps {
   onClose: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onConfirm?: () => void;
   text: string;
+  type?: "alert" | "confirm";
 }
 
-const ModalAlert = ({ isOpen, onClose, onConfirm, text }: ModalAlertProps) => {
+const ModalAlert = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  text,
+  type = "alert",
+}: ModalAlertProps) => {
   if (!isOpen) return null;
 
   const handleConfirmClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -26,12 +33,26 @@ const ModalAlert = ({ isOpen, onClose, onConfirm, text }: ModalAlertProps) => {
           <p className="md:text-[20px] sm:text-[16px] font-[500] mb-8">
             {text}
           </p>
-          <button
-            className="bg-purple100 text-white md:px-[106px] md:py-[11px] sm:px-[84px] sm:py-[9px] rounded-lg hover:opacity-85"
-            onClick={handleConfirmClick}
-          >
-            닫기
-          </button>
+          <div className="flex gap-2">
+            <button
+              className={`md:px-[40px] md:py-[11px] sm:px-[30px] sm:py-[9px] rounded-lg hover:opacity-85 ${
+                type === "confirm"
+                  ? "bg-white100 text-black border border-[gray500]"
+                  : "bg-purple100 text-white"
+              }`}
+              onClick={onClose}
+            >
+              닫기
+            </button>
+            {type === "confirm" && (
+              <button
+                className="bg-purple100 text-white md:px-[40px] md:py-[11px] sm:px-[30px] sm:py-[9px] rounded-lg hover:opacity-85"
+                onClick={handleConfirmClick}
+              >
+                확인
+              </button>
+            )}
+          </div>
         </div>
       </ModalLayout>
     </Portal>


### PR DESCRIPTION


## 🔎 작업 내용

- modalAlert의 type 프롭을 추가하여 alert일때는 닫기버튼만 있고, confirm일때는 닫기와 확인버튼이 나오게 수정했습니다. 
- 해당 기능을 컬럼 관리 모달과 초대자 목록에 적용했습니다. 

  <br/>

## 이미지 첨부

![image (2)](https://github.com/user-attachments/assets/546d4329-9f3e-4866-af34-4aa01d001b7e)
